### PR TITLE
Option to disable ssl cert verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ kws.connect()
 - 2016-04-29	`instruments()` call now returns parsed CSV records.
 - 2016-05-04	Added `historical()` call.
 - 2016-05-09	Added `parent_order_id` param for multi-legged orders.
+- 2016-07-25    Option to disable SSL cert verification (Ubuntu 12.04 openssl bug)

--- a/kiteconnect/__init__.py
+++ b/kiteconnect/__init__.py
@@ -86,6 +86,7 @@ by looking at HTTP codes or JSON error responses. Instead,
 it raises aptly named **[exceptions](exceptions.m.html)** that you can catch.
 """
 from six import StringIO
+import ssl
 import csv
 import json
 import struct
@@ -709,19 +710,24 @@ class WebSocket(object):
 								on_error=self._on_error,
 								on_close=self._on_close)
 
-	def connect(self, threaded=False):
+	def connect(self, threaded=False, disable_ssl=False):
 		"""
 		Start a WebSocket connection as a seperate thread.
 
 		- `threaded` when set to True will open the connection
 			in a new thread without blocking the main thread
+		- `disable_ssl` when set to True will disable ssl cert verifcation. Default is False.
 		"""
-		if not threaded:
-			self.socket.run_forever()
+		sslopt = {}
+		if disable_ssl:
+			sslopt = {"cert_reqs": ssl.CERT_NONE}
 
-		self.websocket_thread = threading.Thread(target=self.socket.run_forever)
-		self.websocket_thread.daemon = True
-		self.websocket_thread.start()
+		if not threaded:
+			self.socket.run_forever(sslopt=sslopt)
+		else:
+			self.websocket_thread = threading.Thread(target=self.socket.run_forever, kwargs={"sslopt": sslopt})
+			self.websocket_thread.daemon = True
+			self.websocket_thread.start()
 
 		return self
 

--- a/kiteconnect/__init__.py
+++ b/kiteconnect/__init__.py
@@ -710,16 +710,16 @@ class WebSocket(object):
 								on_error=self._on_error,
 								on_close=self._on_close)
 
-	def connect(self, threaded=False, disable_ssl=False):
+	def connect(self, threaded=False, disable_ssl_verification=False):
 		"""
 		Start a WebSocket connection as a seperate thread.
 
 		- `threaded` when set to True will open the connection
 			in a new thread without blocking the main thread
-		- `disable_ssl` when set to True will disable ssl cert verifcation. Default is False.
+		- `disable_ssl_verification` when set to True will disable ssl cert verifcation. Default is False.
 		"""
 		sslopt = {}
-		if disable_ssl:
+		if disable_ssl_verification:
 			sslopt = {"cert_reqs": ssl.CERT_NONE}
 
 		if not threaded:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
 	name="kiteconnect",
-	version="3.1.5",
+	version="3.1.6",
 	description="The official Python client for the Kite Connect trading API",
 	author="Rainmatter Technology (India)",
 	author_email="talk@rainmatter.com",


### PR DESCRIPTION
Added option to disable ssl cert verification.

```
from kiteconnect import WebSocket

kws = WebSocket("your_api_key", "your_public_token", "logged_in_user_id")
kws.connect(disable_ssl_verification=True)
```
